### PR TITLE
Prevent automatic snap upgrades

### DIFF
--- a/.github/workflows/naming-lint-unit.yaml
+++ b/.github/workflows/naming-lint-unit.yaml
@@ -7,18 +7,9 @@ jobs:
     uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
     with:
       fail-on-error: "true"
-  lint:
-    name: Lint
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - name: Install Dependencies
-        run: |
-          pip install tox
-      - name: Lint
-        run: tox -vve lint
+
+  lint-unit:
+    name: Lint Unit
+    uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
+    with:
+      python: "['3.8', '3.9', '3.10', '3.11', '3.12']"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.coverage
+*.egg-info/
+__pycache__/

--- a/charms/kubernetes_snaps.py
+++ b/charms/kubernetes_snaps.py
@@ -666,8 +666,7 @@ def is_upgrade(snap_name: str, target_channel: str):
     """
     is_refresh = is_snap_installed(snap_name)
 
-    if is_refresh:
-        installed_version = get_snap_version(snap_name)
+    if is_refresh and (installed_version := get_snap_version(snap_name)):
         channel_version, *_ = target_channel.split("/")
 
         installed_ver = version.parse(installed_version)

--- a/charms/kubernetes_snaps.py
+++ b/charms/kubernetes_snaps.py
@@ -586,8 +586,7 @@ def get_snap_version(name: str) -> str:
     match = re.search(r"\b\d+(?:\.\d+)*\b", output)
 
     if match:
-        version = match.group()
-        return version
+        return match.group()
     else:
         log.info(f"Package '{name}' not found or no version available.")
     return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "charm-lib-contextual-status",
   "ops",
   "PyYAML",
+  "packaging",
 ]
 classifiers = [
   "License :: OSI Approved :: Apache Software License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "Charm library for installing and configuring Kubernetes snaps"
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-  "charm-lib-contextual-status",
+  "charm-lib-contextual-status@git+https://github.com/charmed-kubernetes/charm-lib-contextual-status@main",
   "ops",
   "PyYAML",
   "packaging",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "Charm library for installing and configuring Kubernetes snaps"
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-  "charm-lib-contextual-status@git+https://github.com/charmed-kubernetes/charm-lib-contextual-status@main",
+  "charm-lib-contextual-status@git+https://github.com/charmed-kubernetes/charm-lib-contextual-status",
   "ops",
   "PyYAML",
   "packaging",

--- a/tests/unit/test_kubernetes_snaps.py
+++ b/tests/unit/test_kubernetes_snaps.py
@@ -1,11 +1,6 @@
-from dataclasses import dataclass
-from ops.framework import Framework
-import os
 import pytest
 import unittest.mock as mock
 
-import ops
-import ops.testing
 
 from charms import kubernetes_snaps
 
@@ -16,11 +11,16 @@ def subprocess_check_output():
         yield mock_run
 
 
-
 def test_upgrade_action_control_plane(caplog):
     mock_event = mock.MagicMock()
-    with mock.patch.object(kubernetes_snaps, 'is_upgrade', return_value=False):
-        with mock.patch.object(kubernetes_snaps, 'install_snap'):
+    with mock.patch.object(kubernetes_snaps, "is_upgrade", return_value=False):
+        with mock.patch.object(kubernetes_snaps, "install_snap"):
             kubernetes_snaps.upgrade_snaps("1.28/edge", mock_event, control_plane=True)
-    assert "Starting the upgrade of Kubernetes snaps to '1.28/edge' channel." in caplog.messages
-    assert "Successfully upgraded Kubernetes snaps to the '1.28/edge' channel." in caplog.messages
+    assert (
+        "Starting the upgrade of Kubernetes snaps to '1.28/edge' channel."
+        in caplog.messages
+    )
+    assert (
+        "Successfully upgraded Kubernetes snaps to the '1.28/edge' channel."
+        in caplog.messages
+    )

--- a/tests/unit/test_kubernetes_snaps.py
+++ b/tests/unit/test_kubernetes_snaps.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from ops.framework import Framework
+import os
+import pytest
+import unittest.mock as mock
+
+import ops
+import ops.testing
+
+from charms import kubernetes_snaps
+
+
+@pytest.fixture
+def subprocess_check_output():
+    with mock.patch("charms.kubernetes_snaps.check_output") as mock_run:
+        yield mock_run
+
+
+
+def test_upgrade_action_control_plane(caplog):
+    mock_event = mock.MagicMock()
+    with mock.patch.object(kubernetes_snaps, 'is_upgrade', return_value=False):
+        with mock.patch.object(kubernetes_snaps, 'install_snap'):
+            kubernetes_snaps.upgrade_snaps("1.28/edge", mock_event, control_plane=True)
+    assert "Starting the upgrade of Kubernetes snaps to '1.28/edge' channel." in caplog.messages
+    assert "Successfully upgraded Kubernetes snaps to the '1.28/edge' channel." in caplog.messages

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,14 @@
 # See LICENSE file for licensing details.
 
 [tox]
-no_package = True
 skip_missing_interpreters = True
 env_list = format, lint, unit
 min_version = 4.0.0
 
 [vars]
-src_path = {tox_root}/charms
-all_path = {[vars]src_path}
+src_path = {toxinidir}/charms
+tst_path = {toxinidir}/tests
+all_path = {[vars]src_path} {[vars]tst_path}
 
 [testenv]
 set_env =
@@ -32,6 +32,19 @@ deps =
     ruff
     codespell
 commands =
-    codespell {tox_root}
+    codespell {toxinidir}
     ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
+
+[testenv:unit]
+deps =
+    pytest-cov
+    pytest-html
+commands = 
+    pytest \
+      -vv \
+      --cov={envsitepackagesdir}/charms \
+      --cov-report=term-missing \
+      --tb=native \
+      --log-cli-level=INFO \
+      {posargs:{[vars]tst_path}/unit}


### PR DESCRIPTION
## Summary
This pull request implements a mechanism to prevent automatic upgrades.

## Changes
- Prevent automatic snap upgrades when the `channel` parameter is changed.
- Display `BlockedStatus` if the `channel` parameter has changed and an upgrade is required.