### PR TITLE
Add Kubeconfig Auth to scheduler opts

### DIFF
--- a/charms/kubernetes_snaps.py
+++ b/charms/kubernetes_snaps.py
@@ -417,6 +417,8 @@ def configure_scheduler(extra_args_config, kubeconfig):
 
     scheduler_opts["v"] = "2"
     scheduler_opts["config"] = kube_scheduler_config_path
+    scheduler_opts["authorization-kubeconfig"] = kubeconfig
+    scheduler_opts["authentication-kubeconfig"] = kubeconfig
 
     feature_gates = []
 


### PR DESCRIPTION
## Changes
`kube-scheduler` must use the authorization and authentication kubeconfig for accessing the auth webhook during metrics scraping.