### PR TITLE
[LP#2048683] Only use FQDN node names on AWS when using its cloud-provider

### DIFF
--- a/charms/kubernetes_snaps.py
+++ b/charms/kubernetes_snaps.py
@@ -271,7 +271,7 @@ def configure_kube_proxy(
     kubeconfig,
     external_cloud_provider: ExternalCloud,
 ):
-    fqdn = external_cloud_provider.name == "aws"
+    fqdn = external_cloud_provider.name == "aws" and external_cloud_provider.has_xcp
     kube_proxy_config = {
         "kind": "KubeProxyConfiguration",
         "apiVersion": "kubeproxy.config.k8s.io/v1alpha1",
@@ -361,7 +361,7 @@ def configure_kubelet(
     resolv_path = os.path.realpath("/etc/resolv.conf")
     if resolv_path == "/run/systemd/resolve/stub-resolv.conf":
         kubelet_config["resolvConf"] = "/run/systemd/resolve/resolv.conf"
-    fqdn = external_cloud_provider.name == "aws"
+    fqdn = external_cloud_provider.name == "aws" and external_cloud_provider.has_xcp
 
     kubelet_opts = {}
     kubelet_opts["kubeconfig"] = kubeconfig


### PR DESCRIPTION
[LP#2048683](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2048683)

The aws-cloud-provider application requires that the node-names be in fqdn format, any node names that don't match this when the provider is operating will be deleted automatically.  This handles an upgrade of the cluster if the cloud-provider is added at a later date.