### PR TITLE
Use appropriate permissions on kubeconfig files

### DIFF
--- a/charms/kubernetes_snaps.py
+++ b/charms/kubernetes_snaps.py
@@ -524,7 +524,6 @@ def update_kubeconfig(
         content["users"][0]["user"]["token"] = token
     target_new.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
     target_new.write_text(yaml.safe_dump(content))
-    target_new.chmod(0o600)
     target_new.rename(target)
     return target
 

--- a/tests/unit/test_kubernetes_snaps.py
+++ b/tests/unit/test_kubernetes_snaps.py
@@ -78,7 +78,6 @@ def test_create_kubeconfig(tmp_path):
     )
     assert created == path
     assert created.exists()
-    assert (created.stat().st_mode & 0o777) == 0o600
     text = created.read_text()
     assert "Y2EtZGF0YQ==" in text
     assert "https://192.168.0.1" in text
@@ -88,7 +87,6 @@ def test_create_kubeconfig(tmp_path):
     updated = kubernetes_snaps.update_kubeconfig(path, "new-ca-data")
     assert updated == path
     assert updated.exists()
-    assert (updated.stat().st_mode & 0o777) == 0o600
     text = updated.read_text()
     assert "bmV3LWNhLWRhdGE=" in text
     assert "https://192.168.0.1" in text


### PR DESCRIPTION
we shouldn't change the permissions of this file.  the charm runs as root and creates files that can be read by the ubuntu user. 

The file's permissions by default are 664 and should be left alone. 