### PR TITLE
cdk-addons is no longer a control-plane charm controlled by this library

### DIFF
--- a/charms/kubernetes_snaps.py
+++ b/charms/kubernetes_snaps.py
@@ -44,7 +44,6 @@ CONTROL_PLANE_SNAPS = [
     "kube-apiserver",
     "kube-controller-manager",
     "kube-scheduler",
-    "cdk-addons",
 ]
 
 


### PR DESCRIPTION
## Addresses Issues
[LP#2070379](https://launchpad.net/bugs/2070379)

## Overview
CDK-addons snap is still installed on kubernetes-control-plane units only, but the charm will manage its charm channel since it will be independent from the kubernetes cluster channel.


It's VERY important to merge with
* https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/pull/358