### PR TITLE
Remove PersistentVolumeLabel from enabled admission-plugins

### DIFF
--- a/charms/kubernetes_snaps.py
+++ b/charms/kubernetes_snaps.py
@@ -111,10 +111,11 @@ def configure_apiserver(
     #
     # The list below need only include the plugins we want to enable
     # in addition to the defaults.
-    admission_plugins = [
-        "PersistentVolumeLabel",
-        "NodeRestriction",
-    ]
+    #
+    # In 1.31, PersistentVolumeLabel was no longer available as an admission plugin
+    # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers
+
+    admission_plugins = ["NodeRestriction"]
 
     authorization_modes = authorization_mode.split(",")
     has_authz_webhook = "Webhook" in authorization_modes

--- a/tests/unit/test_kubernetes_snaps.py
+++ b/tests/unit/test_kubernetes_snaps.py
@@ -188,7 +188,7 @@ def test_configure_apiserver(mock_path, configure_kubernetes_service, external_c
         "etcd-certfile": "/root/cdk/etcd/client-cert.pem",
         "etcd-servers": "https://1.1.1.1,https://1.1.1.2",
         "authorization-mode": "Node,RBAC",
-        "enable-admission-plugins": "PersistentVolumeLabel,NodeRestriction",
+        "enable-admission-plugins": "NodeRestriction",
         "requestheader-client-ca-file": "/root/cdk/ca.crt",
         "requestheader-allowed-names": "system:kube-apiserver,client",
         "requestheader-extra-headers-prefix": "X-Remote-Extra-",


### PR DESCRIPTION
## Overview
Addresses [LP#2076056](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2076056) by removing deprecated argument. 

## Details
Prevents the apiserver from enabling a now deprecated admission-plugin. 
https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#persistentvolumelabel


