### PR TITLE
improve upgrade-snaps action to better recover in error cases

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,23 +18,20 @@ set_env =
 
 [testenv:format]
 description = Apply coding style standards to code
-deps =
-    black
-    ruff
+deps = ruff
 commands =
-    black {[vars]all_path}
     ruff format {[vars]all_path}
+    ruff check --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
-    black
     ruff
+    tomli
     codespell
 commands =
     codespell {toxinidir}
     ruff check {[vars]all_path}
-    black --check --diff {[vars]all_path}
 
 [testenv:unit]
 deps =


### PR DESCRIPTION
### Overview

Addresses [LP#2077189](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2077189)
Running outside of a reconcile loop, the action will need to handle errors raised from the install method as `ReconcilerErrors`.

### Details

* These changes promote early reconciliation failures when the `install_snaps` method is called and there's a condition that requires the snaps to be updated. 

* Should be merged with:
   * https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/pull/362
   * https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/177