### PR TITLE
Relax dependecy `charm-lib-contextual-status` when pip installed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "Charm library for installing and configuring Kubernetes snaps"
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-  "charm-lib-contextual-status@git+https://github.com/charmed-kubernetes/charm-lib-contextual-status",
+  "charm-lib-contextual-status",
   "ops",
   "PyYAML",
   "packaging",

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,1 @@
+charm-lib-contextual-status@git+https://github.com/charmed-kubernetes/charm-lib-contextual-status

--- a/tox.ini
+++ b/tox.ini
@@ -15,10 +15,13 @@ all_path = {[vars]src_path} {[vars]tst_path}
 set_env =
     PYTHONBREAKPOINT=pdb.set_trace
     PY_COLORS=1
+deps = -r test_requirements.txt
 
 [testenv:format]
 description = Apply coding style standards to code
-deps = ruff
+deps =
+    {[testenv]deps}
+    ruff
 commands =
     ruff format {[vars]all_path}
     ruff check --fix {[vars]all_path}
@@ -26,17 +29,21 @@ commands =
 [testenv:lint]
 description = Check code against coding style standards
 deps =
+    {[testenv]deps}
     ruff
     tomli
     codespell
+    -r test_requirements.txt
 commands =
     codespell {toxinidir}
     ruff check {[vars]all_path}
 
 [testenv:unit]
 deps =
+    {[testenv]deps}
     pytest-cov
     pytest-html
+    -r test_requirements.txt
 commands = 
     pytest \
       -vv \


### PR DESCRIPTION
### Overview

Don't specify an exact version of  `charm-lib-contextual-status`

### Details

* By not specifying which EXACT version of `charm-lib-contextual-status` is required, downstream an install a specific version.  This relaxation puts the burden on the downstream installer to pick a specific git branch for this dependency
* This means we can make branches of this repo (eg release_1.32, release_1.33, etc...) without having to change this dependency in the pyproject.toml