### PR TITLE
Include the loopback device addresses in kubernetes address list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "Charm library for installing and configuring Kubernetes snaps"
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-  "charm-lib-contextual-status@git+https://github.com/charmed-kubernetes/charm-lib-contextual-status",
+  "charms.contextual-status",
   "ops",
   "PyYAML",
   "packaging",

--- a/tox.ini
+++ b/tox.ini
@@ -18,23 +18,20 @@ set_env =
 
 [testenv:format]
 description = Apply coding style standards to code
-deps =
-    black
-    ruff
+deps = ruff
 commands =
-    black {[vars]all_path}
     ruff format {[vars]all_path}
+    ruff check --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
-    black
     ruff
+    tomli
     codespell
 commands =
     codespell {toxinidir}
     ruff check {[vars]all_path}
-    black --check --diff {[vars]all_path}
 
 [testenv:unit]
 deps =


### PR DESCRIPTION
### Overview
There may be routable addresses on lo other than 127.0.0.1 which the kubernetes cluster can be reached, therefore these addresses can be used by the kubernetes-control-plane to advertise

### Details
* include the `lo` interface when searching for local addresses to host the api server