### PR TITLE
handle 'latest' populated tracks

### DIFF
--- a/tests/unit/test_kubernetes_snaps.py
+++ b/tests/unit/test_kubernetes_snaps.py
@@ -70,6 +70,18 @@ channels:
     assert kubernetes_snaps.is_channel_available("my-snap", "1.29/stable")
 
 
+@mock.patch(
+    "charms.kubernetes_snaps._channel_map",
+    mock.MagicMock(
+        return_value={
+            "1.28/stable": "1.28.7         2025-03-13 (3553) 17MB classic",
+            "1.29/stable": "1.29.3         2025-03-13 (3553) 17MB classic",
+            "1.30/stable": "1.30.0         2025-03-13 (3553) 17MB classic",
+            "latest/stable": "1.30.0         2025-03-13 (3553) 17MB classic",
+            "1.31/stable": "--",
+        }
+    ),
+)
 def test_is_channel_swap(subprocess_call, subprocess_check_output):
     snap_list = """
 Name     Version       Rev    Tracking       Publisher   Notes
@@ -80,6 +92,11 @@ my-snap  1.29.0        22606  1.29/stable    canonical✓  -
     assert kubernetes_snaps.is_channel_swap("my-snap", "1.28/stable")
     assert not kubernetes_snaps.is_channel_swap("my-snap", "1.29/stable")
     assert kubernetes_snaps.is_channel_swap("my-snap", "1.30/stable")
+    assert kubernetes_snaps.is_channel_swap("my-snap", "latest/stable")
+    with pytest.raises(kubernetes_snaps.SnapInstallError):
+        kubernetes_snaps.is_channel_swap("my-snap", "1.31/stable")
+    with pytest.raises(kubernetes_snaps.SnapInstallError):
+        kubernetes_snaps.is_channel_swap("my-snap", "invalid/stable")
 
 
 @pytest.fixture(params=[None, "external"])


### PR DESCRIPTION
### Overview
if the charm config calls for upgrading to the `latest/stable` or any other track with a non-numerical value, that should be okay as long as the track has a revision populated in it. 

### Details

* Look for a revision in the channel map in hopes that it is numerical
* Raises in the event there is no numerical revision in the track
* determine if its a channel swap based on the numerical revision rather than channel revision:
    * eg) if currently = `1.2.3` and the newly configured channel contains `1.2.3`, then this isn't really channel swap