### PR TITLE
Remove cloud-provider args from kube-apiserver

### DIFF
--- a/charms/kubernetes_snaps.py
+++ b/charms/kubernetes_snaps.py
@@ -70,9 +70,13 @@ def configure_apiserver(
     extra_args_config,
     privileged,
     service_cidr,
-    external_cloud_provider: ExternalCloud,
+    external_cloud_provider: ExternalCloud,  # pylint: disable=unused-argument
     authz_webhook_conf_file: Optional[Path] = None,
 ):
+    """Configures the kube-apiserver arguments and config file based on current
+    relations.
+    """
+
     api_opts = {}
     feature_gates = []
 
@@ -158,12 +162,6 @@ def configure_apiserver(
     api_opts["proxy-client-key-file"] = "/root/cdk/client.key"
     api_opts["enable-aggregator-routing"] = "true"
     api_opts["client-ca-file"] = "/root/cdk/ca.crt"
-
-    if external_cloud_provider.has_xcp:
-        log.info("KubeApi: Uses an External Cloud Provider")
-        api_opts["cloud-provider"] = "external"
-    else:
-        log.info("KubeApi: No Cloud Features")
 
     api_opts["feature-gates"] = ",".join(feature_gates)
 

--- a/tests/unit/test_kubernetes_snaps.py
+++ b/tests/unit/test_kubernetes_snaps.py
@@ -226,6 +226,5 @@ def test_configure_apiserver(mock_path, configure_kubernetes_service, external_c
         "audit-policy-file": "/some/path",
         "audit-webhook-config-file": "/some/path",
     }
-    if external_cloud.has_xcp:
-        expected_args["cloud-provider"] = "external"
+    assert "cloud-provider" not in expected_args
     assert expected_args == args


### PR DESCRIPTION
### Overview
`cloud-provider` is not an argument accepted by kube-apiserver

### Details
* https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/ doesn't reference `cloud-provider` as an argument in `kube-apiserver` and in 1.33 it actively disallows it:

```
Apr 21 14:51:36 juju-a10194-0 kube-apiserver.daemon[98328]: Error: unknown flag: --cloud-provider
Apr 21 14:51:36 juju-a10194-0 systemd[1]: snap.kube-apiserver.daemon.service: Main process exited, code=exited, status=1/FAILURE
Apr 21 14:51:36 juju-a10194-0 systemd[1]: snap.kube-apiserver.daemon.service: Failed with result 'exit-code'.
```